### PR TITLE
Move `crypto-browserify` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "bn.js": "=2.0.4",
     "bs58": "=2.0.0",
     "buffer-compare": "=1.0.0",
+    "crypto-browserify": "git://github.com/decred/crypto-browserify.git#master-legacy",
     "elliptic": "=3.0.3",
     "inherits": "=2.0.1",
     "lodash": "=3.10.1"
@@ -91,7 +92,6 @@
     "bitcore-build": "bitpay/bitcore-build",
     "brfs": "^1.2.0",
     "chai": "^1.10.0",
-    "crypto-browserify": "git://github.com/decred/crypto-browserify.git#master-legacy",
     "gulp": "^3.8.10",
     "sinon": "^1.13.0"
   },


### PR DESCRIPTION
Because `crypto-browserify` is used in [hash.js](https://github.com/decred/bitcore/blob/a92381b2b0023b28a1b7eb03e6cb0bfb7800200d/lib/crypto/hash.js#L4)