### PR TITLE
Use package blake-hash

### DIFF
--- a/lib/crypto/hash.js
+++ b/lib/crypto/hash.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var crypto = require('crypto');
-var cryptoB = require('crypto-browserify');
+var createBlakeHash = require('blake-hash');
 var BufferUtil = require('../util/buffer');
 var $ = require('../util/preconditions');
 
@@ -48,7 +48,7 @@ Hash.doubleblake256 = function(buf) {
 
 Hash.blake256 = function(buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return cryptoB.createHash('blake256').update(buf).digest();
+  return createBlakeHash('blake256').update(buf).digest();
 }
 
 Hash.sha512 = function(buf) {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "request": "browser-request"
   },
   "dependencies": {
+    "blake-hash": "^1.0.0",
     "bn.js": "=2.0.4",
     "bs58": "=2.0.0",
     "buffer-compare": "=1.0.0",
@@ -91,7 +92,6 @@
     "bitcore-build": "bitpay/bitcore-build",
     "brfs": "^1.2.0",
     "chai": "^1.10.0",
-    "crypto-browserify": "git://github.com/decred/crypto-browserify.git#master-legacy",
     "gulp": "^3.8.10",
     "sinon": "^1.13.0"
   },


### PR DESCRIPTION
Related with #7 

with `crypto-browserify` fork:
```js
> require('./').crypto.Hash.blake256(Buffer.alloc(0))
Error: Digest method not supported
```