### PR TITLE
add and link hxlivenet and hxtestnet configurations

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  network: 'dcrdlivenet',
+  network: 'hxlivenet',
   logger: 'debug' // none, normal, debug
 };

--- a/dcr-peer.js
+++ b/dcr-peer.js
@@ -26,11 +26,13 @@ var run = function() {
     };
 
     var peerman = new PeerManager({
-	network: 'dcrdtestnet'
+    network: 'hxtestnet'
+	// network: 'dcrdtestnet'
 	//network: 'testnet'
     });
 
-    peerman.addPeer(new Peer('127.0.0.1', 19108));
+    peerman.addPeer(new Peer('127.0.0.1', 12008));
+    // peerman.addPeer(new Peer('127.0.0.1', 19108));
     //peerman.addPeer(new Peer('127.0.0.1', 18333));
     peerman.on('connection', function(conn) {
 	conn.on('inv', handleInv);

--- a/lib/Address.js
+++ b/lib/Address.js
@@ -49,7 +49,7 @@ EncodedData.applyEncodingsTo(Address);
 // create a pubKeyHash address
 Address.fromPubKey = function(pubKey, network) {
   if (!network)
-    network = 'dcrdlivenet';
+    network = 'hxlivenet';
 
   if (pubKey.length !== 33 && pubKey.length !== 65)
     throw new Error('Invalid public key');
@@ -68,7 +68,7 @@ Address.fromKey = function(key, network) {
 // create a p2sh m-of-n multisig address
 Address.fromPubKeys = function(mReq, pubKeys, network, opts) {
   if (!network)
-    network = 'dcrdlivenet';
+    network = 'hxlivenet';
 
   for (var i in pubKeys) {
     var pubKey = pubKeys[i];
@@ -83,7 +83,7 @@ Address.fromPubKeys = function(mReq, pubKeys, network, opts) {
 //create a p2sh address from redeemScript
 Address.fromScript = function(script, network) {
   if (!network)
-    network = 'dcrdlivenet';
+    network = 'hxlivenet';
 
   if (typeof script === 'string') {
     script = new Script(new Buffer(script, 'hex'));
@@ -104,7 +104,7 @@ Address.fromScriptPubKey = function(scriptPubKey, network) {
   }
 
   if (!network)
-    network = 'dcrdlivenet';
+    network = 'hxlivenet';
 
   var ret = [],
     version;
@@ -147,14 +147,22 @@ Address.prototype.validate = function() {
 // returns the network information (livenet or testnet, as described on networks.js) of the address
 Address.prototype.network = function() {
   var version = this.version();
-  var livenet = networks.dcrdlivenet;
-  var testnet = networks.dcrdtestnet;
+  var livenet = networks.hxlivenet;
+  var testnet = networks.hxtestnet;
 
   var answer;
-  if (version === livenet.addressVersion || version === livenet.P2SHVersion)
+  if (version === livenet.addressVersion ||
+    version === livenet.blissAddressVersion ||
+    version === livenet.P2SHVersion)
+  {
     answer = livenet;
-  else if (version === testnet.addressVersion || version === testnet.P2SHVersion)
+  }
+  else if (version === testnet.addressVersion ||
+    version === testnet.blissAddressVersion ||
+    version === testnet.P2SHVersion)
+  {
     answer = testnet;
+  }
 
   return answer;
 };
@@ -167,8 +175,8 @@ Address.prototype.isScript = function() {
 // returns the scriptPubKey
 Address.prototype.getScriptPubKey = function() {
   var version = this.version();
-  var livenet = networks.dcrdlivenet;
-  var testnet = networks.dcrdtestnet;
+  var livenet = networks.hxlivenet;
+  var testnet = networks.hxtestnet;
 
   var script;
   if (version === livenet.addressVersion || version === testnet.addressVersion)
@@ -197,7 +205,7 @@ Address.fromScriptSig = function(scriptSig, network) {
     scriptSig = new Script(scriptSigBuf);
   }
   if (!network)
-    network = 'dcrdlivenet';
+    network = 'hxlivenet';
 
   var payload = scriptSig.chunks;
   if (scriptSig.chunks.length === 2)

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -27,7 +27,7 @@ var BIP0031_VERSION = 60000;
 function Connection(socket, peer, opts) {
   this.config = opts || bitcoreDefaults;
 
-  this.network = networks[this.config.network] || networks.dcrdlivenet;
+  this.network = networks[this.config.network] || networks.hxlivenet;
   this.socket = socket;
   this.peer = peer;
 

--- a/lib/HierarchicalKey.js
+++ b/lib/HierarchicalKey.js
@@ -15,13 +15,13 @@ from extended public or private key: new HierarchicalKey(str);
 new blank HierarchicalKey: new HierarchicalKey(null);
 */
 var HierarchicalKey = function(bytes) {
-  if (typeof bytes == 'undefined' || bytes == 'mainnet' || bytes == 'dcrdlivenet') {
-    bytes = 'dcrdlivenet';
-    this.version = networks['dcrdlivenet'].hkeyPrivateVersion;
-  } else if (bytes == 'dcrdtestnet') {
-    this.version = networks['dcrdtestnet'].hkeyPrivateVersion;
+  if (typeof bytes == 'undefined' || bytes == 'mainnet' || bytes == 'hxlivenet') {
+    bytes = 'hxlivenet';
+    this.version = networks['hxlivenet'].hkeyPrivateVersion;
+  } else if (bytes == 'hxtestnet') {
+    this.version = networks['hxtestnet'].hkeyPrivateVersion;
   }
-  if (bytes == 'dcrdlivenet' || bytes == 'dcrdtestnet') {
+  if (bytes == 'hxlivenet' || bytes == 'hxtestnet') {
     this.depth = 0x00;
     this.parentFingerprint = new Buffer([0, 0, 0, 0]);
     this.childIndex = new Buffer([0, 0, 0, 0]);
@@ -55,7 +55,7 @@ var HierarchicalKey = function(bytes) {
 
 HierarchicalKey.seed = function(bytes, network) {
   if (!network)
-    network = 'dcrdlivenet';
+    network = 'hxlivenet';
 
   if (!Buffer.isBuffer(bytes))
     bytes = new Buffer(bytes, 'hex'); //if not buffer, assume hex
@@ -96,12 +96,12 @@ HierarchicalKey.prototype.initFromBytes = function(bytes) {
   var keyBytes = bytes.slice(45, 78);
 
   var isPrivate =
-    (this.version == networks['dcrdlivenet'].hkeyPrivateVersion ||
-      this.version == networks['dcrdtestnet'].hkeyPrivateVersion);
+    (this.version == networks['hxlivenet'].hkeyPrivateVersion ||
+      this.version == networks['hxtestnet'].hkeyPrivateVersion);
 
   var isPublic =
-    (this.version == networks['dcrdlivenet'].hkeyPublicVersion ||
-      this.version == networks['dcrdtestnet'].hkeyPublicVersion);
+    (this.version == networks['hxlivenet'].hkeyPublicVersion ||
+      this.version == networks['hxtestnet'].hkeyPublicVersion);
 
   if (isPrivate && keyBytes[0] == 0) {
     this.eckey = new Key();
@@ -128,13 +128,13 @@ HierarchicalKey.prototype.buildExtendedPublicKey = function() {
 
   var v = null;
   switch (this.version) {
-    case networks['dcrdlivenet'].hkeyPublicVersion:
-    case networks['dcrdlivenet'].hkeyPrivateVersion:
-      v = networks['dcrdlivenet'].hkeyPublicVersion;
+    case networks['hxlivenet'].hkeyPublicVersion:
+    case networks['hxlivenet'].hkeyPrivateVersion:
+      v = networks['hxlivenet'].hkeyPublicVersion;
       break;
-    case networks['dcrdtestnet'].hkeyPublicVersion:
-    case networks['dcrdtestnet'].hkeyPrivateVersion:
-      v = networks['dcrdtestnet'].hkeyPublicVersion;
+    case networks['hxtestnet'].hkeyPublicVersion:
+    case networks['hxtestnet'].hkeyPrivateVersion:
+      v = networks['hxtestnet'].hkeyPublicVersion;
       break;
     default:
       throw new Error('Unknown version');
@@ -246,8 +246,8 @@ HierarchicalKey.prototype.deriveChild = function(i) {
   var usePrivate = (i & 0x80000000) != 0;
 
   var isPrivate =
-    (this.version == networks['dcrdlivenet'].hkeyPrivateVersion ||
-      this.version == networks['dcrdtestnet'].hkeyPrivateVersion);
+    (this.version == networks['hxlivenet'].hkeyPrivateVersion ||
+      this.version == networks['hxtestnet'].hkeyPrivateVersion);
 
   if (usePrivate && (!this.hasPrivateKey || !isPrivate))
     throw new Error('Cannot do private key derivation without private key');

--- a/lib/PrivateKey.js
+++ b/lib/PrivateKey.js
@@ -67,8 +67,8 @@ PrivateKey.prototype.compressed = function(compressed) {
 PrivateKey.prototype.network = function() {
   var version = this.version();
 
-  var livenet = networks.dcrdlivenet;
-  var testnet = networks.dcrdtestnet;
+  var livenet = networks.hxlivenet;
+  var testnet = networks.hxtestnet;
 
   var answer;
   if (version === livenet.privKeyVersion)

--- a/lib/TransactionBuilder.js
+++ b/lib/TransactionBuilder.js
@@ -151,8 +151,7 @@ TransactionBuilder.infoForP2sh = function(opts, networkName) {
   var script = this._scriptForOut(opts);
   var hash = util.sha256ripe160(script.getBuffer());
 
-  var version = networkName === 'dcrdtestnet' ?
-    networks.dcrdtestnet.P2SHVersion : networks.dcrdlivenet.P2SHVersion;
+  var version = networks[networkName].P2SHVersion;
 
   var addr = new Address(version, hash);
   var addrStr = addr.as('base58');
@@ -471,7 +470,7 @@ TransactionBuilder.prototype._checkTx = function() {
 
 TransactionBuilder.prototype._multiFindKey = function(walletKeyMap, pubKeyHash) {
   var wk;
-  [networks.dcrdlivenet, networks.dcrdtestnet].forEach(function(n) {
+  [networks.hxlivenet, networks.hxtestnet].forEach(function(n) {
     [n.addressVersion, n.P2SHVersion].forEach(function(v) {
       var a = new Address(v, pubKeyHash);
       if (!wk && walletKeyMap[a]) {

--- a/lib/Wallet.js
+++ b/lib/Wallet.js
@@ -69,6 +69,12 @@ Wallet.prototype.setNetwork = function(netname) {
     case "dcrdtestnet":
       this.network = networks.dcrdtestnet;
       break;
+    case "hxlivenet":
+      this.network = networks.hxlivenet;
+      break;
+    case "hxtestnet":
+      this.network = networks.hxtestnet;
+      break;
     default:
       throw new Error("Unsupported network");
   }

--- a/lib/WalletKey.js
+++ b/lib/WalletKey.js
@@ -7,7 +7,7 @@ var networks = require('../networks');
 
 function WalletKey(cfg) {
   if (!cfg) cfg = {};
-  this.network = cfg.network || networks.dcrdlivenet;
+  this.network = cfg.network || networks.hxlivenet;
   this.created = cfg.created;
   this.privKey = cfg.privKey;
 };

--- a/networks.js
+++ b/networks.js
@@ -114,3 +114,51 @@ exports.dcrdtestnet = {
   ],
   defaultClientPort: 19108
 };
+
+
+exports.hxlivenet = {
+  name: 'hxlivenet',
+  magic: hex('1bf52511'),
+  addressVersion: 0x097f,
+  blissAddressVersion: 0x0957,
+  privKeyVersion: 0x19ab,
+  P2SHVersion: 0x095a,
+  hkeyPublicVersion: 0x02fda926,
+  hkeyPrivateVersion: 0x02fda4e8,
+  genesisBlock: {
+    hash: hex('80d9212bf4ceb066ded2866b39d4ed89e0ab60f335c11df8e7bf85d9c35c8e29'), //
+    merkle_root: hex('4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b'),
+    height: 0,
+    nonce: 2083236893,
+    version: 1,
+    prev_hash: buffertools.fill(new Buffer(32), 0),
+    timestamp: 1296688602,
+    bits: "207ffffff",
+  },
+  dnsSeeds: [],
+  defaultClientPort: 14009
+};
+
+
+exports.hxtestnet = {
+  name: 'hxtestnet',
+  magic: hex('3a69b59a'),
+  addressVersion: 0x0f21,
+  blissAddressVersion: 0x0ef8,
+  privKeyVersion: 0x230e,
+  P2SHVersion: 0x0efc,
+  hkeyPublicVersion: 0x043587d1,
+  hkeyPrivateVersion: 0x04358397,
+  genesisBlock: {
+    hash: hex('9cc27bbd461958ffc4ed7767492e905477a0a64ba62176d40ad8079d2a606142'),
+    merkle_root: hex('a216ea043f0d481a072424af646787794c32bcefd3ed181a090319bbf8a37105'),
+    height: 0,
+    nonce: 414098458,
+    version: 4,
+    prev_hash: buffertools.fill(new Buffer(32), 0),
+    timestamp: 1489550400,
+    bits: "1e00ffff",
+  },
+  dnsSeeds: [],
+  defaultClientPort: 12009
+};


### PR DESCRIPTION
- add hx configurations to network params
- update relevant files to use `hxlivenet` as default network is undefined
- update addresses to support bliss version addresses
- update relevant files' hardcodes of live/test networks to use hx